### PR TITLE
feat(keychain): Integrate keychain ssh-agent correctly using nushell

### DIFF
--- a/aliases.nu
+++ b/aliases.nu
@@ -53,7 +53,7 @@ export alias eet = sudo pacman -Rns
 # ------------------------------------------------------------------------------
 # changing the binding of the man command to point directly to batman instead of
 # man. This is to facilitate colorizing the man commands output.
-export alias man = batman
+# export alias man = nvim
 
 # ------------------------------------------------------------------------------
 # correctly set up the replacements for the following commands, to more sensible


### PR DESCRIPTION
The evaluation mechanic that is normally used in shells is not available in nushell due to the inherent limitations in rust. We have to rework the initialization of the tool differently, namely using the string parsing functions that nushell provides to correctly load the environment variables.