### PR TITLE
Nu scripts submodularize

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "nu_scripts"]
 	path = nu_scripts
 	url = https://github.com/nushell/nu_scripts.git
+[submodule "lib/nu_scripts"]
+	path = lib/nu_scripts
+	url = https://github.com/nushell/nu_scripts

--- a/alias_candy.nu
+++ b/alias_candy.nu
@@ -1,3 +1,4 @@
+# vim: set ft=nu ts=2 sts=2 sw=2 et:
 #!/usr/bin/env nu
 
 # ------------------------------------------------------------------------------
@@ -7,3 +8,12 @@
 # the aliases.
 # -----
 export alias candy = git --git-dir $env.DOTCANDYD_USER_HOME --work-tree $env.HOME
+
+# -----------------------------------------------------------------------------
+# set up an alias that can unlock our bw cli tool as needed. This authentication
+# token is very dangerous if exposed...keep it safe in .envrc.secrets, but by
+# being an alias, the evaluation is deferred until the value is strictly
+# necessary, and not when this file gets compiled (which is before the envrc
+# hooks)
+# -----
+export alias bw-unlock = bw unlock --raw --passwordenv "RSP_URSA_MAJOR_AUTHKEY"

--- a/config.nu
+++ b/config.nu
@@ -182,6 +182,7 @@ let carapace_completer = {|spans|
     carapace $spans.0 nushell $spans | from json
 }
 
+use ~/.config/nushell/alias_candy.nu bw-unlock
 
 # The default config record. This is where much of your global configuration is setup.
 let-env config = {
@@ -311,7 +312,7 @@ let-env config = {
       let direnv = if ($direnv | length) == 1 { $direnv } else { {} }
       $direnv | load-env
 
-      let-env BW_SESSION = (bw unlock --raw --passwordenv "RSP_URSA_MAJOR_AUTHKEY")
+      let-env BW_SESSION = (bw-unlock)
     }]
     pre_execution: [{||
       null  # replace with source code to run before the repl input is run

--- a/env.nu
+++ b/env.nu
@@ -88,16 +88,6 @@ let-env NU_PLUGIN_DIRS = [
     ($nu.default-config-dir | path join 'plugins')
 ]
 
-# To add entries to PATH (on Windows you might use Path), you can use the following pattern:
-# let-env PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
-
-
-# ────────────────────────────────────────────────────────────-----------------
-# User configurations can go below here. This is mostly defining the env.nu.d
-# folder with corresponding source in pieces in typical linux fashion.
-#let pathstr = ([$env.HOME, "/.config/nushell/env.nu.d/*.nu"] | str join)
-#ls $pathstr | get name | each {|e| source $e }
-
 # define the dotcandyd systems home folder here. this is used in the nushell
 # configuration definition of the candy cli
 let-env DOTCANDYD_USER_HOME = ($env.HOME | path join ".candy.d")


### PR DESCRIPTION
We have added a basic configuration to the nushell setup, wherein the nu_scripts repository hosted on the official nushell github page, is submodularized within my own configuration. Now we can easily keep it up to date while directly loading the scripts and configuration materials within to nushell on startup.